### PR TITLE
ci(codecov): migrate to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: Test suite
+---
+name: CI
 on:
   push:
     branches: [master]
@@ -23,4 +24,4 @@ jobs:
         uses: codecov/codecov-action@v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: .coverage
+          files: .coverage


### PR DESCRIPTION
## Summary by Sourcery

Migrate the CI workflow to use the v5 Codecov action, rename the workflow, and adjust the coverage file parameter

CI:
- Rename GitHub Actions workflow from “Test suite” to “CI”
- Change Codecov action parameter from “file” to “files” for v5 compatibility