### PR TITLE
chore(cd): rename environment to 'publish' and update artifact attachment step description

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write  # IMPORTANT: Mandatory for Trusted Publishing (gh-action-pypi-publish)
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment:
-      name: release
+      name: publish
       url: https://pypi.org/project/asgi-user-agents/${{ github.ref_name }}
     steps:
       - name: Checkout repository
@@ -35,7 +35,7 @@ jobs:
         run: uv build --no-sources --quiet
       - name: Publish to PyPI
         run: uv publish --quite --trusted-publishing always
-      - name: Attach Release Artifacts
+      - name: Attach Build Artifacts to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} ./dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main, master]
   pull_request:
-    branches: [master]
+    branches: [main, master]
 jobs:
   tests:
     name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ cache-keys = [
   { file = "pyproject.toml" },
   { git = { commit = true, tags = true } },
 ]
+trusted-publishing = "always"
 
 
 [tool.hatch.envs.default]


### PR DESCRIPTION
## Summary by Sourcery

Rename CD workflow environment and update artifact step name, and expand CI workflow to run on both main and master branches

Enhancements:
- Clarify the artifact attachment step name in CD workflow

Chores:
- Rename environment in CD workflow from 'release' to 'publish'
- Add 'main' branch to CI push and pull_request triggers