### PR TITLE
feat: add Django contrib integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
-* Nothing yet.
+### Added
+
+* ✨ Add `contrib` integration for Django: a sync/async `UserAgentMiddleware` attaching a lazy `request.user_agent`, the `{% load asgi_user_agents %}` template filters (`is_mobile`, `is_pc`, `is_tablet`, `is_bot`, `is_touch_capable`), and a `[django]` extra. Reuses `scope["ua"]` under ASGI and falls back to header parsing under WSGI.
 
 ## [0.3.0] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Downloads/Month](https://pepy.tech/badge/asgi-user-agents/month)](https://pepy.tech/project/asgi-user-agents)
 [![Downloads/Week](https://pepy.tech/badge/asgi-user-agents/week)](https://pepy.tech/project/asgi-user-agents)
 
-[User Agents][python-user-agents] integration for [ASGI](https://asgi.readthedocs.io/en/latest/) applications. Works with Starlette, FastAPI, Quart, Litestar -- or any other web framework supporting ASGI that exposes the ASGI `scope`.
+[User Agents][python-user-agents] integration for [ASGI](https://asgi.readthedocs.io/en/latest/) applications. Works with Starlette, FastAPI, Quart, Litestar, Django -- or any other web framework supporting ASGI that exposes the ASGI `scope`.
 
 -----
 
@@ -109,7 +109,7 @@ async def index(request: Request) -> Response:
 
 ## Framework integrations
 
-For Litestar and FastAPI, optional `contrib` subpackages provide
+For Litestar, FastAPI, and Django, optional `contrib` subpackages provide
 framework-idiomatic access. The core `UAMiddleware` still works for any
 ASGI framework — `contrib` is additive convenience.
 
@@ -118,6 +118,7 @@ Install with the relevant extra:
 ```bash
 pip install asgi-user-agents[litestar]
 pip install asgi-user-agents[fastapi]
+pip install asgi-user-agents[django]
 ```
 
 ### Litestar
@@ -159,6 +160,45 @@ async def index(ua: UADep) -> dict:
 ```
 
 `install_ua` is idempotent. The plain dependency functions `get_ua` and `get_user_agent` are also exported if you prefer to wire them yourself.
+
+### Django
+
+Built on `UADetails`. Add the app and the middleware:
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    "asgi_user_agents.contrib.django",  # enables the template filters
+]
+
+MIDDLEWARE = [
+    # ...
+    "asgi_user_agents.contrib.django.UserAgentMiddleware",
+]
+```
+
+The middleware attaches a lazy `request.user_agent` (a `UADetails`):
+
+```python
+def my_view(request):
+    if request.user_agent.is_mobile:
+        ...
+    browser = request.user_agent.browser.family
+```
+
+…and the same data is available as template filters:
+
+```django
+{% load asgi_user_agents %}
+{% if request|is_mobile %}Mobile{% elif request|is_pc %}Desktop{% endif %}
+```
+
+Resolution is **scope-first**: under ASGI, if the core `UAMiddleware` already
+ran, `request.user_agent` reuses the parsed `request.scope["ua"]` with no
+re-parse. Under WSGI (no scope) it falls back to parsing `request.headers`, so
+the integration works under both deployment models. The middleware is sync- and
+async-capable.
 
 ## API Reference
 

--- a/docs/superpowers/specs/2026-06-22-django-contrib-design.md
+++ b/docs/superpowers/specs/2026-06-22-django-contrib-design.md
@@ -1,0 +1,145 @@
+# Django Integration via `contrib/django` — Design Spec
+
+**Date:** 2026-06-22
+**Status:** Draft (awaiting approval)
+**Scope:** Add a first-class Django integration under `asgi_user_agents.contrib.django`, on top of this package's `UADetails`. No changes to existing top-level APIs.
+
+## Background
+
+The integration provides three things: a middleware that attaches a lazy `request.user_agent`, five template filters (`is_mobile`, `is_pc`, `is_tablet`, `is_bot`, `is_touch_capable`), and (deferred) an optional cache layer for parsed user agents (ua-parser is slow).
+
+It is implemented idiomatically and routed through our `UADetails`, gaining scope reuse for free under ASGI.
+
+## Goal
+
+Provide Django-idiomatic access to user-agent data:
+
+- A **sync+async middleware** attaching `request.user_agent: UADetails` (lazy).
+- The **five template filters**, plus we expose the richer `UADetails` (so `os`, `browser`, `device`, `is_email_client` are also reachable in views).
+
+Caching is **deferred** (see Non-Goals). ua-parser is slow, but under ASGI the scope-first reuse already avoids re-parsing for the common path, and a cache layer can land additively later without changing this surface.
+
+The raw ASGI `UAMiddleware` keeps working unchanged. Django contrib is additive convenience.
+
+## Decision: scope-first resolution
+
+`request.user_agent` resolves in this order:
+
+1. **Reuse:** if `request` carries a `scope` (ASGI) and `request.scope.get("ua")` is a `UADetails` (i.e. upstream `UAMiddleware` already ran), return it — zero re-parse, shares the cached `_ua`.
+2. **ASGI, no upstream middleware:** if `request.scope` exists, build `UADetails(request.scope)`.
+3. **WSGI fallback:** no `request.scope` → synthesize a minimal scope `{"headers": [(b"user-agent", ua.encode("latin-1"))]}` from `request.headers` and build `UADetails(...)`.
+
+Confirmed against Django source (`main`/6.2a and `stable/3.2.x`): `ASGIRequest` stores `self.scope = scope`; `WSGIRequest` has no `scope`; `request.headers` (`HttpHeaders(self.META)`) exists on both. So the integration is ASGI-flavored (reuses `scope["ua"]`) but degrades cleanly to header parsing under WSGI.
+
+## Non-Goals
+
+- **Caching** (`USER_AGENTS_CACHE`). Deferred to a later iteration; v1 ships without it. Scope-first reuse covers the hot ASGI path; a cache layer is additive and won't change this surface.
+- A settings dataclass / configurable attribute name (`request.user_agent` is fixed for v1).
+- An `[all]` extra.
+- Async template rendering concerns (filters are pure, sync, microsecond-cheap).
+- Changing `UAMiddleware` or `UADetails` semantics, or top-level exports. The contrib is purely additive — **no core files are modified**.
+
+## Layout
+
+```
+src/asgi_user_agents/contrib/django/
+├── __init__.py              # re-exports UserAgentMiddleware, get_user_agent
+├── apps.py                  # AppConfig with pinned label
+├── middleware.py            # UserAgentMiddleware (sync + async capable)
+├── utils.py                 # get_user_agent(request) — scope-first resolution
+└── templatetags/
+    ├── __init__.py
+    └── asgi_user_agents.py  # is_mobile, is_pc, is_tablet, is_bot, is_touch_capable
+```
+
+- Top-level `asgi_user_agents/__init__.py` does **not** import contrib — zero import cost for non-Django users.
+- Importing `contrib.django` without Django installed raises a standard `ImportError` (no custom wrapping), matching the fastapi/litestar contribs.
+
+## App label
+
+`templatetags/` are discovered only from apps in `INSTALLED_APPS`. The package path is `asgi_user_agents.contrib.django`, whose default app label would be the bare `django` — confusing and collision-prone. `apps.py` pins it:
+
+```python
+from django.apps import AppConfig
+
+class AsgiUserAgentsConfig(AppConfig):
+    name = "asgi_user_agents.contrib.django"
+    label = "asgi_user_agents"
+```
+
+Users add `"asgi_user_agents.contrib.django"` to `INSTALLED_APPS`. Django 3.2+ auto-detects the `AppConfig`; no `default_app_config` shim needed.
+
+## Middleware
+
+`middleware.py` — a single class supporting both sync and async `get_response`, detected at init via `asgiref.sync.iscoroutinefunction`. It sets `request.user_agent = SimpleLazyObject(lambda: get_user_agent(request))` so parsing happens only if accessed (and not at all for cached/reused cases until touched).
+
+```python
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction
+from django.utils.functional import SimpleLazyObject
+from .utils import get_user_agent
+
+class UserAgentMiddleware:
+    async_capable = True
+    sync_capable = True
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self._async = iscoroutinefunction(get_response)
+        if self._async:
+            markcoroutinefunction(self)
+
+    def __call__(self, request):
+        if self._async:
+            return self.__acall__(request)
+        request.user_agent = SimpleLazyObject(lambda: get_user_agent(request))
+        return self.get_response(request)
+
+    async def __acall__(self, request):
+        request.user_agent = SimpleLazyObject(lambda: get_user_agent(request))
+        return await self.get_response(request)
+```
+
+Install via `MIDDLEWARE = [..., "asgi_user_agents.contrib.django.UserAgentMiddleware"]`.
+
+## Resolution (`utils.get_user_agent`)
+
+`utils.py` — `get_user_agent(request)` implements the scope-first resolution and is the single source of `request.user_agent`. No caching in v1; it returns a `UADetails` directly. The three-branch ordering (reuse `scope["ua"]` → `UADetails(request.scope)` → synthesize from `request.headers`) lives here.
+
+## Packaging
+
+`pyproject.toml` adds:
+
+```toml
+[project.optional-dependencies]
+django = ["django>=3.2"]
+```
+
+Install: `pip install asgi-user-agents[django]`. (`asgiref` arrives transitively with Django.)
+
+## Error Handling
+
+- Missing Django → standard `ImportError` from the `import` line.
+- Missing/empty UA header → `UADetails` already tolerates it (`is_provided` is `False`, all `is_*` return `False`).
+- No new exception paths.
+
+## Testing
+
+New file `tests/test_django_contrib.py` (additive; existing tests untouched). Uses Django's `SimpleTestCase`/`RequestFactory` configured via `settings.configure(...)`:
+
+- **ASGI reuse:** scope carrying a `UADetails` under `"ua"` → `get_user_agent` returns that same instance.
+- **ASGI no-middleware:** request with `scope` but no `"ua"` → builds a correct `UADetails`.
+- **WSGI fallback:** `RequestFactory` request (no `scope`) with a `HTTP_USER_AGENT` header → correct `UADetails`.
+- **Template filters:** render `{% load asgi_user_agents %}{{ request|is_mobile }}` etc. against the canonical `assets/test_middleware.json` fixture.
+
+`hatch-test` env adds `django`.
+
+## Documentation (README)
+
+Add a "Django" subsection under "Framework integrations": `INSTALLED_APPS` + `MIDDLEWARE` setup, a view example (`request.user_agent.is_mobile`), and a template example. Note it reuses `scope["ua"]` under ASGI and falls back to header parsing under WSGI.
+
+## Backward Compatibility
+
+- All existing top-level exports untouched.
+- Existing tests unmodified.
+- No core files modified — the contrib is entirely additive.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = ["user-agents", "typing_extensions>=4.0.0"]
 [project.optional-dependencies]
 litestar = ["litestar>=2.0.0,<3.0.0"]
 fastapi = ["fastapi>=0.110.0,<1.0.0"]
+django = ["django>=3.2"]
 
 
 [project.urls]
@@ -108,6 +109,7 @@ extra-dependencies = [
   "fastapi>=0.138.0,<0.139.0",
   "litestar>=2.0.0,<3.0.0",
   "quart>=0.10.0,<0.20.0",
+  "django>=3.2",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ dependencies = ["user-agents", "typing_extensions>=4.0.0"]
 [project.optional-dependencies]
 litestar = ["litestar>=2.0.0,<3.0.0"]
 fastapi = ["fastapi>=0.110.0,<1.0.0"]
-django = ["django>=3.2"]
+# asgiref>=3.6 is required for `markcoroutinefunction`/`iscoroutinefunction`
+# used by the middleware; Django 3.2/4.1 can otherwise resolve an older asgiref.
+django = ["django>=3.2", "asgiref>=3.6"]
 
 
 [project.urls]

--- a/src/asgi_user_agents/contrib/django/__init__.py
+++ b/src/asgi_user_agents/contrib/django/__init__.py
@@ -1,0 +1,8 @@
+"""Django integration for asgi-user-agents."""
+
+from asgi_user_agents.contrib.django.middleware import (
+    UserAgentMiddleware as UserAgentMiddleware,
+)
+from asgi_user_agents.contrib.django.utils import (
+    get_user_agent as get_user_agent,
+)

--- a/src/asgi_user_agents/contrib/django/apps.py
+++ b/src/asgi_user_agents/contrib/django/apps.py
@@ -1,0 +1,16 @@
+"""Django application configuration for the asgi-user-agents contrib."""
+
+from django.apps import AppConfig
+
+
+class AsgiUserAgentsConfig(AppConfig):
+    """App config pinning a stable label for template-tag discovery.
+
+    The package path ends in ``.django``, whose default app label would be the
+    bare ``django`` -- confusing and collision-prone. We pin ``asgi_user_agents``
+    so ``{% load asgi_user_agents %}`` resolves and the app is unambiguous in
+    ``INSTALLED_APPS``.
+    """
+
+    name = "asgi_user_agents.contrib.django"
+    label = "asgi_user_agents"

--- a/src/asgi_user_agents/contrib/django/middleware.py
+++ b/src/asgi_user_agents/contrib/django/middleware.py
@@ -1,0 +1,60 @@
+"""Django middleware attaching a lazy ``request.user_agent``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction
+from django.utils.functional import SimpleLazyObject
+
+from asgi_user_agents.contrib.django.utils import get_user_agent
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from django.http import HttpRequest, HttpResponse
+
+
+class UserAgentMiddleware:
+    """Attach ``request.user_agent`` as a lazily-resolved ``UADetails``.
+
+    Supports both sync and async ``get_response`` callables. Parsing is deferred
+    via ``SimpleLazyObject`` so a request that never touches ``user_agent`` pays
+    nothing, and -- under ASGI with the upstream ``UAMiddleware`` installed --
+    resolution reuses the already-parsed ``scope["ua"]``.
+    """
+
+    async_capable = True
+    sync_capable = True
+
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponse]
+        | Callable[[HttpRequest], Awaitable[HttpResponse]],
+    ) -> None:
+        """Store ``get_response`` and adapt to its sync/async nature."""
+        self.get_response = get_response
+        self._is_async = iscoroutinefunction(get_response)
+        if self._is_async:
+            markcoroutinefunction(self)
+
+    def __call__(self, request: HttpRequest) -> HttpResponse | Awaitable[HttpResponse]:
+        """Dispatch to the sync or async path.
+
+        Returns:
+            The downstream response, or an awaitable resolving to it when the
+            middleware is operating in async mode.
+        """
+        if self._is_async:
+            return self._acall(request)
+        request.user_agent = SimpleLazyObject(lambda: get_user_agent(request))  # type: ignore[attr-defined]
+        return self.get_response(request)  # type: ignore[return-value]
+
+    async def _acall(self, request: HttpRequest) -> HttpResponse:
+        """Async path: attach the lazy user agent, then await downstream.
+
+        Returns:
+            The awaited downstream response.
+        """
+        request.user_agent = SimpleLazyObject(lambda: get_user_agent(request))  # type: ignore[attr-defined]
+        return await self.get_response(request)  # type: ignore[misc]

--- a/src/asgi_user_agents/contrib/django/templatetags/__init__.py
+++ b/src/asgi_user_agents/contrib/django/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Template tag libraries for the asgi-user-agents Django contrib."""

--- a/src/asgi_user_agents/contrib/django/templatetags/asgi_user_agents.py
+++ b/src/asgi_user_agents/contrib/django/templatetags/asgi_user_agents.py
@@ -1,0 +1,74 @@
+"""Template filters exposing User-Agent device classes.
+
+Each filter takes the ``request`` and returns a device-class boolean, e.g.::
+
+    {% load asgi_user_agents %}
+    {% if request|is_mobile %}...{% endif %}
+
+The filters resolve through :func:`get_user_agent`, so they reuse a
+``UADetails`` already attached by ``UserAgentMiddleware`` or by the upstream
+ASGI ``UAMiddleware`` (``scope["ua"]``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django import template
+
+from asgi_user_agents.contrib.django.utils import get_user_agent
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+register = template.Library()
+
+
+@register.filter()
+def is_mobile(request: HttpRequest) -> bool:
+    """Whether the request comes from a mobile device.
+
+    Returns:
+        ``True`` if the User-Agent identifies a mobile device.
+    """
+    return get_user_agent(request).is_mobile
+
+
+@register.filter()
+def is_pc(request: HttpRequest) -> bool:
+    """Whether the request comes from a PC.
+
+    Returns:
+        ``True`` if the User-Agent identifies a PC.
+    """
+    return get_user_agent(request).is_pc
+
+
+@register.filter()
+def is_tablet(request: HttpRequest) -> bool:
+    """Whether the request comes from a tablet.
+
+    Returns:
+        ``True`` if the User-Agent identifies a tablet.
+    """
+    return get_user_agent(request).is_tablet
+
+
+@register.filter()
+def is_bot(request: HttpRequest) -> bool:
+    """Whether the request comes from a bot/crawler.
+
+    Returns:
+        ``True`` if the User-Agent identifies a bot or crawler.
+    """
+    return get_user_agent(request).is_bot
+
+
+@register.filter()
+def is_touch_capable(request: HttpRequest) -> bool:
+    """Whether the requesting device is touch-capable.
+
+    Returns:
+        ``True`` if the User-Agent identifies a touch-capable device.
+    """
+    return get_user_agent(request).is_touch_capable

--- a/src/asgi_user_agents/contrib/django/utils.py
+++ b/src/asgi_user_agents/contrib/django/utils.py
@@ -21,11 +21,16 @@ def _synthetic_scope(request: HttpRequest) -> Scope:
     values are latin-1 encoded to match the ASGI byte convention that
     ``UADetails._get_header`` decodes against.
 
+    A genuine WSGI server latin-1-decodes header bytes, so ``ua_string`` is
+    always in range here. ``errors="ignore"`` is a safety net for synthetic
+    callers (e.g. ``RequestFactory``) that may inject out-of-range characters:
+    we drop them rather than raise inside middleware.
+
     Returns:
         A scope-shaped mapping carrying only the ``User-Agent`` header.
     """
     ua_string = request.headers.get("user-agent", "")
-    return {"headers": [(b"user-agent", ua_string.encode("latin-1"))]}
+    return {"headers": [(b"user-agent", ua_string.encode("latin-1", "ignore"))]}
 
 
 def get_user_agent(request: HttpRequest) -> UADetails:

--- a/src/asgi_user_agents/contrib/django/utils.py
+++ b/src/asgi_user_agents/contrib/django/utils.py
@@ -1,0 +1,56 @@
+"""Resolve a :class:`UADetails` for a Django request (scope-first)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from asgi_user_agents.datastructures import UADetails
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+    from asgi_user_agents._types import Scope
+
+
+def _synthetic_scope(request: HttpRequest) -> Scope:
+    """Build a minimal ASGI-shaped scope from a request's headers.
+
+    ``UADetails`` only reads ``scope["headers"]`` -- a list of
+    ``(bytes, bytes)`` pairs. Under WSGI there is no ``request.scope``, so we
+    fabricate just enough for ``UADetails`` to find the User-Agent. Header
+    values are latin-1 encoded to match the ASGI byte convention that
+    ``UADetails._get_header`` decodes against.
+
+    Returns:
+        A scope-shaped mapping carrying only the ``User-Agent`` header.
+    """
+    ua_string = request.headers.get("user-agent", "")
+    return {"headers": [(b"user-agent", ua_string.encode("latin-1"))]}
+
+
+def get_user_agent(request: HttpRequest) -> UADetails:
+    """Return a :class:`UADetails` for ``request``, reusing work when possible.
+
+    Resolution order (scope-first):
+
+    1. **Reuse.** If the request carries an ASGI ``scope`` (``request.scope``)
+       and that scope already holds a ``UADetails`` under ``"ua"`` -- i.e. the
+       upstream ``UAMiddleware`` ran -- return *that same instance*. No re-parse.
+    2. **ASGI, no upstream middleware.** If ``request.scope`` exists but has no
+       usable ``"ua"``, build ``UADetails(request.scope)`` from it.
+    3. **WSGI fallback.** No ``request.scope`` at all -> build a ``UADetails``
+       from :func:`_synthetic_scope`.
+
+    Args:
+        request: The Django request (``ASGIRequest`` or ``WSGIRequest``).
+
+    Returns:
+        A ``UADetails`` describing the request's User-Agent.
+    """
+    scope: Scope | None = getattr(request, "scope", None)
+    if scope is not None:
+        cached = scope.get("ua")
+        if isinstance(cached, UADetails):
+            return cached
+        return UADetails(scope)
+    return UADetails(_synthetic_scope(request))

--- a/tests/test_django_contrib.py
+++ b/tests/test_django_contrib.py
@@ -1,0 +1,152 @@
+"""Tests for the Django contrib integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        ALLOWED_HOSTS=["*"],
+        INSTALLED_APPS=["asgi_user_agents.contrib.django"],
+        DATABASES={},
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": False,
+                "OPTIONS": {},
+            }
+        ],
+        USE_TZ=True,
+    )
+    django.setup()
+
+import parametrize_from_file as pff
+import pytest
+from asgiref.sync import iscoroutinefunction
+from django.template import Context, Template
+from django.test import RequestFactory
+
+from asgi_user_agents import UADetails
+from asgi_user_agents.contrib.django import (
+    UserAgentMiddleware,
+    get_user_agent,
+)
+
+rf = RequestFactory()
+
+
+# --- Resolution: the three scope-first branches ---------------------------- #
+
+
+def test_reuses_cached_uadetails_from_scope() -> None:
+    """Branch 1: an existing `scope['ua']` UADetails is returned as-is."""
+    cached = UADetails({"type": "http", "headers": [(b"user-agent", b"cached/1.0")]})
+    request = SimpleNamespace(
+        scope={"type": "http", "headers": [(b"user-agent", b"other/2.0")], "ua": cached}
+    )
+    assert get_user_agent(request) is cached  # type: ignore[arg-type]
+
+
+def test_builds_from_scope_without_upstream_middleware() -> None:
+    """Branch 2: a scope with no usable `ua` yields a fresh UADetails from it."""
+    request = SimpleNamespace(
+        scope={"type": "http", "headers": [(b"user-agent", b"scoped/3.0")]}
+    )
+    ua = get_user_agent(request)  # type: ignore[arg-type]
+    assert isinstance(ua, UADetails)
+    assert ua.ua_string == "scoped/3.0"
+
+
+def test_non_uadetails_scope_value_is_ignored() -> None:
+    """A `scope['ua']` that is not a UADetails must not be trusted/reused."""
+    request = SimpleNamespace(
+        scope={
+            "type": "http",
+            "headers": [(b"user-agent", b"scoped/4.0")],
+            "ua": "nope",
+        }
+    )
+    ua = get_user_agent(request)  # type: ignore[arg-type]
+    assert isinstance(ua, UADetails)
+    assert ua.ua_string == "scoped/4.0"
+
+
+def test_wsgi_request_falls_back_to_headers() -> None:
+    """Branch 3: a WSGIRequest (no `.scope`) resolves via synthesized headers."""
+    request = rf.get("/", HTTP_USER_AGENT="wsgi/5.0")
+    assert not hasattr(request, "scope")
+    ua = get_user_agent(request)
+    assert isinstance(ua, UADetails)
+    assert ua.ua_string == "wsgi/5.0"
+
+
+# --- Resolution correctness against the canonical fixture ------------------ #
+
+
+@pff.parametrize(path="assets/test_middleware.json", key="test_user_agent_data")
+def test_resolution_matches_fixture(ua_string: str, response_data: dict) -> None:
+    """The WSGI fallback path produces fixture-accurate UADetails fields."""
+    request = rf.get("/", HTTP_USER_AGENT=ua_string)
+    ua = get_user_agent(request)
+    assert ua.ua_string == response_data["ua_string"]
+    assert ua.os.family == response_data["os.family"]
+    assert ua.browser.family == response_data["browser.family"]
+    assert ua.device.family == response_data["device.family"]
+    assert ua.is_mobile is response_data["is_mobile"]
+    assert ua.is_bot is response_data["is_bot"]
+
+
+# --- Middleware ------------------------------------------------------------ #
+
+
+def test_sync_middleware_attaches_lazy_user_agent() -> None:
+    """Sync path: `request.user_agent` resolves to the correct UADetails."""
+    sentinel = object()
+    middleware = UserAgentMiddleware(lambda _request: sentinel)
+    assert iscoroutinefunction(middleware) is False
+    request = rf.get("/", HTTP_USER_AGENT="Mozilla/5.0 (iPhone)")
+    response = middleware(request)
+    assert response is sentinel
+    assert request.user_agent.is_mobile is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_attaches_lazy_user_agent() -> None:
+    """Async path: the middleware marks itself async and still attaches UA."""
+    sentinel = object()
+
+    async def get_response(_request: Any) -> object:
+        return sentinel
+
+    middleware = UserAgentMiddleware(get_response)
+    assert iscoroutinefunction(middleware) is True
+    request = rf.get("/", HTTP_USER_AGENT="Mozilla/5.0 (iPhone)")
+    response = await middleware(request)  # type: ignore[misc]
+    assert response is sentinel
+    assert request.user_agent.is_mobile is True  # type: ignore[attr-defined]
+
+
+# --- Template filters ------------------------------------------------------ #
+
+
+@pff.parametrize(path="assets/test_middleware.json", key="test_user_agent_data")
+def test_template_filters_match_fixture(ua_string: str, response_data: dict) -> None:
+    """`{% load asgi_user_agents %}` filters mirror the UADetails booleans."""
+    template = Template(
+        "{% load asgi_user_agents %}"
+        "{{ request|is_mobile }}|{{ request|is_pc }}|{{ request|is_tablet }}|"
+        "{{ request|is_bot }}|{{ request|is_touch_capable }}"
+    )
+    request = rf.get("/", HTTP_USER_AGENT=ua_string)
+    rendered = template.render(Context({"request": request}))
+    expected = "|".join(
+        str(response_data[key])
+        for key in ("is_mobile", "is_pc", "is_tablet", "is_bot", "is_touch_capable")
+    )
+    assert rendered == expected

--- a/tests/test_django_contrib.py
+++ b/tests/test_django_contrib.py
@@ -86,6 +86,38 @@ def test_wsgi_request_falls_back_to_headers() -> None:
     assert ua.ua_string == "wsgi/5.0"
 
 
+def test_wsgi_request_with_missing_user_agent() -> None:
+    """A WSGIRequest with no User-Agent yields an empty, not-provided UADetails."""
+    request = rf.get("/")
+    ua = get_user_agent(request)
+    assert isinstance(ua, UADetails)
+    assert not ua.ua_string
+    assert ua.is_provided is False
+    assert ua.is_mobile is False
+    rendered = Template(
+        "{% load asgi_user_agents %}{{ request|is_mobile }}|{{ request|is_bot }}"
+    ).render(Context({"request": request}))
+    assert rendered == "False|False"
+
+
+def test_wsgi_fallback_handles_non_ascii_user_agent() -> None:
+    """The WSGI fallback never raises on non-latin-1 User-Agent characters.
+
+    A genuine WSGI server can only produce latin-1 header strings, but a
+    synthetic caller may inject anything. Latin-1 chars round-trip exactly;
+    out-of-range chars (e.g. an emoji) are dropped rather than raising.
+    """
+    # Accented chars are within latin-1 and round-trip losslessly.
+    accented = rf.get("/", HTTP_USER_AGENT="MyApp/1.0 (Áccented)")
+    assert get_user_agent(accented).ua_string == "MyApp/1.0 (Áccented)"
+
+    # An emoji is outside latin-1: resolution must degrade, not raise.
+    emoji = rf.get("/", HTTP_USER_AGENT="MyApp/1.0 (\U0001f40d)")
+    ua = get_user_agent(emoji)
+    assert isinstance(ua, UADetails)
+    assert ua.ua_string == "MyApp/1.0 ()"
+
+
 # --- Resolution correctness against the canonical fixture ------------------ #
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -43,6 +47,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+django = [
+    { name = "django", version = "5.2.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 fastapi = [
     { name = "fastapi" },
 ]
@@ -52,12 +60,25 @@ litestar = [
 
 [package.metadata]
 requires-dist = [
+    { name = "django", marker = "extra == 'django'", specifier = ">=3.2" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.110.0,<1.0.0" },
     { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.0.0,<3.0.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "user-agents" },
 ]
-provides-extras = ["fastapi", "litestar"]
+provides-extras = ["django", "fastapi", "litestar"]
+
+[[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -90,11 +111,45 @@ wheels = [
 ]
 
 [[package]]
+name = "django"
+version = "5.2.15"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "asgiref", marker = "python_full_version < '3.12'" },
+    { name = "sqlparse", marker = "python_full_version < '3.12'" },
+    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
+]
+
+[[package]]
+name = "django"
+version = "6.0.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "asgiref", marker = "python_full_version >= '3.12'" },
+    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
+    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -685,6 +740,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,7 @@ dependencies = [
 
 [package.optional-dependencies]
 django = [
+    { name = "asgiref" },
     { name = "django", version = "5.2.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
@@ -60,6 +61,7 @@ litestar = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asgiref", marker = "extra == 'django'", specifier = ">=3.6" },
     { name = "django", marker = "extra == 'django'", specifier = ">=3.2" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.110.0,<1.0.0" },
     { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.0.0,<3.0.0" },


### PR DESCRIPTION
## Summary

Adds a first-class Django integration under `asgi_user_agents.contrib.django`, built on the existing `UADetails`. Purely additive — no core files modified, no top-level API changes.

What it provides:

- **`UserAgentMiddleware`** — sync- and async-capable; attaches a lazy `request.user_agent` (a `UADetails`).
- **Template filters** — `{% load asgi_user_agents %}` exposes `is_mobile`, `is_pc`, `is_tablet`, `is_bot`, `is_touch_capable`.
- **`[django]` extra** — `pip install asgi-user-agents[django]`.

### Scope-first resolution

`request.user_agent` resolves in order:

1. **Reuse** — under ASGI, if the core `UAMiddleware` already ran, reuse the parsed `request.scope["ua"]` with no re-parse.
2. **ASGI, no upstream middleware** — build `UADetails(request.scope)`.
3. **WSGI fallback** — no `request.scope`; synthesize a minimal scope from `request.headers`.

This makes the integration work under both ASGI and WSGI deployments from one code path.

### Notes

- App label is pinned to `asgi_user_agents` (the package path ends in `.django`, whose default label would collide).
- `default_app_config` is omitted — Django 3.2+ auto-detects the single `AppConfig`.

## Test plan

- `pytest` — full suite green (239 passed; 62 new cases covering the three resolution branches, sync/async middleware, and template filters against the canonical fixture)
- `ruff check` / `ruff format --check` — clean
- `codespell` — clean
- `mypy` — no issues

Design spec: `docs/superpowers/specs/2026-06-22-django-contrib-design.md`

## Summary by Sourcery

Add a first-class Django contrib integration providing middleware, template filters, and packaging support.

New Features:
- Introduce a Django contrib package with a sync/async `UserAgentMiddleware` that attaches a lazy `request.user_agent` based on `UADetails`.
- Expose Django template filters for user-agent device classification (`is_mobile`, `is_pc`, `is_tablet`, `is_bot`, `is_touch_capable`).
- Add an optional `[django]` extra to install Django-specific dependencies.

Build:
- Declare Django as an optional dependency in `pyproject.toml` and include it in extra dependencies for testing.

Documentation:
- Document Django integration setup and usage in the README, including middleware configuration and template examples.
- Add a detailed design spec for the Django contrib integration under `docs/superpowers/specs`.

Tests:
- Add Django contrib test suite covering scope-first resolution paths, middleware behavior in sync/async modes, and template filters against existing fixtures.