### PR TITLE
ci: harden workflows with pinned actions and refresh dev tooling

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,18 +16,21 @@ jobs:
       url: https://pypi.org/project/asgi-user-agents/${{ github.ref_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version-file: '.python-version'
       - name: Setup uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
       - name: Restore cache
         if: steps.setup-uv.outputs.cache-hit == 'true'
         run: echo "Cache was restored"
@@ -38,4 +41,4 @@ jobs:
       - name: Attach Build Artifacts to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} ./dist/*
+        run: gh release upload ${{ github.ref_name }} ./dist/* --clobber

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -10,11 +10,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Lint PR Title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -32,7 +32,7 @@ jobs:
             ```
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Hatch
         uses: pypa/hatch@install
       - name: Check Types
@@ -21,7 +21,7 @@ jobs:
       - name: Run Coverage
         run: hatch test --cover
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: trailing-whitespace
         name: Trailing whitespace
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: 0.37.3
     hooks:
       - id: check-github-actions
         name: Validate GitHub Actions
@@ -48,7 +48,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.18
     hooks:
       - id: ruff
         name: Ruff Linter

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "extends": ["config:recommended"],
-  "labels": ["internal"],
-  "semanticCommits": "enabled"
+  "extends": ["github>hasansezertasan/renovate-config:python"]
 }


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions setup across the repo and refreshes dev tooling, inspired by the more battle-tested release pipeline in [`hasansezertasan/cobo`](https://github.com/hasansezertasan/cobo) — **without** adopting `release-please` itself. The curated `CHANGELOG.md` and manual release-notes flow stay exactly as they are.

## Changes

### Supply-chain hardening — pin all actions to commit SHAs
Floating tags (`@v7`, `@v3`, …) are mutable; a re-tagged action could silently change what runs. All actions are now pinned to immutable commit digests, with the version kept in a trailing comment so Renovate can still track upgrades.

- `cd.yml` — `actions/checkout` (v7.0.0), `actions/setup-python` (v6.2.0), `astral-sh/setup-uv` (v8.2.0)
- `ci.yml` — `actions/checkout` (v7.0.0), `codecov/codecov-action` (v7.0.0)
- `check-pr-title.yml` — `amannn/action-semantic-pull-request` (v6.1.1), `marocchino/sticky-pull-request-comment` (v3.0.4)

### Resilient PyPI publish (`cd.yml`)
- Add `cache-dependency-glob` (`pyproject.toml`, `uv.lock`) to `setup-uv` for reliable cache invalidation.
- Add `--clobber` to `gh release upload` so re-running a failed publish doesn't error on already-uploaded artifacts.

### Dev tooling refresh
- `.pre-commit-config.yaml` — bump `check-jsonschema` to `0.37.3` and `ruff-pre-commit` to `v0.15.18`.
- `renovate.json` — replace inline config with the shared `github>hasansezertasan/renovate-config:python` preset.

## Notes
- No behavioral change to versioning or changelog generation.
- SHA pins were resolved and verified against the upstream tags before pinning.