### PR TITLE
ci: report coverage to Codecov via tokenless XML upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,83 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+env:
+  PYTHONUNBUFFERED: "1"
+  FORCE_COLOR: "1"
 jobs:
   tests:
-    name: Run tests
+    name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Hatch
+        run: pip install --upgrade hatch
+      - name: Check types
+        if: matrix.os == 'ubuntu-latest' && (matrix.python-version == '3.10' || matrix.python-version == '3.14')
+        run: hatch run +py=${{ matrix.python-version }} types:all
+      - name: Run tests
+        run: hatch test --cover-quiet -py ${{ matrix.python-version }}
+      - name: Rename coverage data
+        shell: bash
+        run: mv .coverage ".coverage.${{ matrix.os }}-${{ matrix.python-version }}"
+      - name: Upload coverage files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
+          path: .coverage.*
+          retention-days: 1
+          include-hidden-files: true
+  coverage:
+    name: Coverage Report
+    needs:
+      - tests
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-      - name: Install Hatch
-        uses: pypa/hatch@install
-      - name: Check Types
-        run: hatch run types:all
-      - name: Run Tests
-        run: hatch test -a
-      - name: Run Coverage
-        run: hatch test --cover
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7.0.0
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: .coverage
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: ".python-version"
+      - name: Setup uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+      - name: Restore cache
+        if: steps.setup-uv.outputs.cache-hit == 'true'
+        run: echo "Cache was restored"
+      - name: Download coverage files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+      - name: Install coverage
+        run: uv tool install coverage[toml]
+      - name: Coverage Report
+        run: |
+          uv tool run coverage combine
+          uv tool run coverage report
+          uv tool run coverage xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        with:
+          files: coverage.xml


### PR DESCRIPTION
## Summary

Reworks CI coverage reporting (inspired by [openapipages](https://github.com/hasansezertasan/openapipages)) so Codecov actually receives a parseable report.

The previous step uploaded the raw `.coverage` SQLite binary, which Codecov cannot parse — nothing was being reported. CI is now split into two jobs:

- **`tests`** — matrix of Linux/Windows/macOS × Python 3.10–3.14 (`fail-fast: false`). Runs `hatch test --cover-quiet`, renames the result to a unique `.coverage.<os>-<py>`, and uploads it as an artifact. Type-checking is preserved, gated to Ubuntu + Py 3.10/3.14.
- **`coverage`** — downloads all artifacts, runs `coverage combine → report → xml`, and uploads `coverage.xml` to Codecov.

## Notes

- **Tokenless** Codecov upload (no `CODECOV_TOKEN`); the `CODECOV_TOKEN` repo secret can be removed.
- Added `concurrency` (cancel superseded runs) and pinned all actions to commit SHAs.
- Hatch auto-combines into a single `.coverage`, so each matrix leg is renamed to a unique name to avoid clobbering on download; `coverage combine` re-globs them downstream. The combine→xml flow was verified locally.

## Summary by Sourcery

Rework CI to run a cross-platform Python test matrix and generate a combined coverage XML report uploaded to Codecov.

New Features:
- Add a multi-OS, multi-Python GitHub Actions matrix for running tests and collecting coverage artifacts.
- Introduce a dedicated coverage job that combines per-matrix coverage data and uploads a coverage.xml report to Codecov without using a token.

Enhancements:
- Enable workflow-level concurrency to cancel superseded CI runs and set common environment variables for consistent output.
- Pin all GitHub Actions (checkout, setup-python, artifact upload/download, setup-uv, Codecov) to specific commit SHAs for reproducible CI behavior.

CI:
- Split the CI workflow into separate tests and coverage jobs, with type-checking limited to selected Ubuntu/Python combinations and coverage aggregation handled centrally.