### PR TITLE
docs: auto-generate collapsible ToC with md-toc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
         name: Codespell Spell Checker
         additional_dependencies:
           - tomli
+  - repo: https://github.com/frnmst/md-toc
+    rev: 9.0.0
+    hooks:
+      - id: md-toc
+        name: Markdown Table of Contents
+        args: [-p, -s, "1", github, -l, "6"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.18
     hooks:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@
 
 -----
 
-## Table of Contents
+<details>
+<summary>Table of Contents</summary>
 
-<!-- toc -->
+<!--TOC-->
 
 - [Installation](#installation)
 - [How does it work?](#how-does-it-work)
@@ -25,6 +26,7 @@
 - [Framework integrations](#framework-integrations)
   - [Litestar](#litestar)
   - [FastAPI](#fastapi)
+  - [Django](#django)
 - [API Reference](#api-reference)
   - [`UAMiddleware`](#uamiddleware)
   - [`UADetails`](#uadetails)
@@ -41,7 +43,9 @@
 - [Analysis](#analysis)
 - [License](#license)
 
-<!-- tocstop -->
+<!--TOC-->
+
+</details>
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Adopt automated, drift-free README table of contents generation, modeled on [litestar-org/litestar](https://github.com/litestar-org/litestar).

- Add the [`frnmst/md-toc`](https://github.com/frnmst/md-toc) pre-commit hook (pinned `rev: 9.0.0`), pure-Python so it fits the existing hook stack with no Node dependency.
- Restructure the ToC into a collapsible `<details><summary>Table of Contents</summary>` block — no H1 title, no self-referencing entry, H2s at top level.
- Hook args `[-p, -s, "1", github, -l, "6"]` write in place, skip the H1 line, and use GitHub-flavored anchors. Verified idempotent.
- Fixes the stale ToC: adds the missing **Django** framework-integration entry (introduced in #121).

## Why

The previous ToC was hand-maintained and had already drifted (missing Django). The `<!--TOC-->` markers now bound an auto-regenerated list, so the section stays in sync as headings change.