### PR TITLE
ci: grant contents:write so cd.yml can upload release artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ jobs:
     name: Publish on PyPI
     permissions:
       id-token: write  # IMPORTANT: Mandatory for Trusted Publishing (gh-action-pypi-publish)
+      contents: write  # Required for `gh release upload` to attach build artifacts
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment:
       name: publish


### PR DESCRIPTION
## Summary

The `publish-pypi` job in `cd.yml` declares `permissions: id-token: write` for PyPI Trusted Publishing. Declaring any permission flips `GITHUB_TOKEN` to deny-by-default, so the **Attach Build Artifacts to GitHub Release** step (`gh release upload`) had no write access.

The 0.3.0 release ([run](https://github.com/hasansezertasan/asgi-user-agents/actions/runs/27137254974/job/80092711007)) published to PyPI successfully but failed this step with:

> HTTP 403: Resource not accessible by integration

This adds `contents: write` so the artifact upload succeeds on the next tagged release.

## Test plan

- [ ] Next release tag triggers `cd.yml` and the artifact-upload step passes

## Summary by Sourcery

Build:
- Update cd.yml workflow permissions to include contents: write for release artifact uploads.